### PR TITLE
Rethinkdb connection management

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "recluster": "^0.4.5",
     "require-dir": "^0.3.0",
     "rethinkdb": "^2.3.0",
+    "rethinkdbdash": "^2.3.6",
     "rosie": "^1.3.0",
     "run-sequence": "^1.1.5",
     "selenium-standalone": "^5.0.0",

--- a/server/db.js
+++ b/server/db.js
@@ -1,17 +1,14 @@
-const r = require('rethinkdb');
+// const r = require('rethinkdb');
+const r = require('rethinkdbdash')();
 
 module.exports = {
-  establishConnection: async() => {
-    return await r.connect({host: 'localhost', port: 28015});
-  },
-
-  init: async({name, tables}, conn) => {
+  init: async({name, tables}) => {
     let db;
     const dbName = name || process.env.NODE_ENV;
     try {
-      db = await r.dbCreate(dbName).run(conn);
+      db = await r.dbCreate(dbName).run();
       for (let table of tables) {
-        await r.db(dbName).tableCreate(table).run(conn);
+        await r.db(dbName).tableCreate(table).run();
       }
     } catch (err) {
       throw(err);
@@ -19,31 +16,31 @@ module.exports = {
     return db;
   },
 
-  changes: async({name, tableName}, cb, conn) => {
+  changes: async({name, tableName}, cb) => {
     const dbName = name || process.env.NODE_ENV;
-    return await r.db(dbName).table(tableName).changes().run(conn, cb);
+    return await r.db(dbName).table(tableName).changes().run(cb);
   },
 
-  get: async({name, tableName, id}, conn) => {
+  get: async({name, tableName, id}) => {
     const dbName = name || process.env.NODE_ENV;
-    return await r.db(dbName).table(tableName).get(id).run(conn);
+    return await r.db(dbName).table(tableName).get(id).run();
   },
 
-  insert: async({name, tableName, data}, conn) => {
+  insert: async({name, tableName, data}) => {
     const dbName = name || process.env.NODE_ENV;
-    return await r.db(dbName).table(tableName).insert(data).run(conn);
+    return await r.db(dbName).table(tableName).insert(data).run();
   },
 
-  update: async({name, tableName, id, data}, conn) => {
+  update: async({name, tableName, id, data}) => {
     const dbName = name || process.env.NODE_ENV;
-    return await r.db(dbName).table(tableName).get(id).update(data).run(conn);
+    return await r.db(dbName).table(tableName).get(id).update(data).run();
   },
 
-  listDbs: async(conn) => {
-    return await r.dbList().run(conn);
+  listDbs: async() => {
+    return await r.dbList().run();
   },
 
-  drop: async(name, conn) => {
-    await r.dbDrop(name).run(conn);
+  drop: async(name) => {
+    await r.dbDrop(name).run();
   }
 };

--- a/server/event_api.js
+++ b/server/event_api.js
@@ -23,12 +23,8 @@ const tableUpdateHandler = generateEventListener('data', (message, listener, tab
 });
 
 function dbChangeListener(listener, tableName) {
-  db.establishConnection()
-  .then((conn) => {
-    db.changes({tableName}, function(err, feed) {
-      if (err) conn.close();
-      tableUpdateHandler(feed, listener, tableName);
-    }, conn);
+  db.changes({tableName}, function(err, feed) {
+    tableUpdateHandler(feed, listener, tableName);
   });
 };
 

--- a/server/events.js
+++ b/server/events.js
@@ -2,24 +2,15 @@ const db = require('./db');
 const {generateEventListener, generateEventListeners, dbChangeListener} = require('./event_api');
 
 const playlistIdEventListener = generateEventListener('playlistId', (id, listener) => {
-  let conn;
-  return db.establishConnection()
-  .then((connection) => {
-    conn = connection;
-    return db.get({tableName: 'playlists', id}, conn);
-  })
+  return db.get({tableName: 'playlists', id})
   .then((data) => {
     listener.emit(`playlists${id}`, data);
-    conn.close();
   });
 });
 
 const playlistUpdateEventListener = generateEventListener('playlistUpdate', (data) => {
   const {id} = data;
-  return db.establishConnection()
-  .then((conn) => {
-    return db.update({tableName: 'playlists', id, data}, conn);
-  });
+  return db.update({tableName: 'playlists', id, data});
 });
 
 const dbPlaylistUpdate = (io) => dbChangeListener(io, 'playlists');

--- a/spec/server/db_spec.js
+++ b/spec/server/db_spec.js
@@ -1,41 +1,22 @@
 require('./spec_helper');
-const r = require('rethinkdb');
+const r = require('rethinkdbdash')();
+const db = require('../../server/db');
 
 describe('Db', () => {
-  let db, conn;
-
-  beforeEach(async(done) => {
-    db = require('../../server/db');
-    conn = await db.establishConnection();
-    done();
-  });
-
-  afterEach(() => {
-    conn.close();
-  });
-
-  describe('#establishConnection', () => {
-    it('establishes a connection to the database', async(done) => {
-      expect(conn.host).toEqual('localhost');
-      expect(conn.port).toEqual(28015);
-      done();
-    });
-  });
-
   describe('#init and #drop', () => {
     beforeEach(async(done) => {
-      await db.init({name: 'testDB', tables: ['moretest', 'testtest']}, conn);
+      await db.init({name: 'testDB', tables: ['moretest', 'testtest']});
       done();
     });
 
     it('creates the database with tables', async(done) => {
-      let dbs = await r.dbList().run(conn);
+      let dbs = await r.dbList().run();
       let lastCreatedDb = dbs.pop();
       expect(lastCreatedDb).toEqual('testDB');
 
-      await db.drop('testDB', conn);
+      await db.drop('testDB');
 
-      dbs = await r.dbList().run(conn);
+      dbs = await r.dbList().run();
       lastCreatedDb = dbs.pop();
       expect(lastCreatedDb).not.toEqual('testDB');
 

--- a/spec/server/events_spec.js
+++ b/spec/server/events_spec.js
@@ -1,16 +1,14 @@
 require('./spec_helper');
 const io = require('socket.io-client');
+const db = require('../../server/db');
 
-let event, conn, playlist, clientSocket, db;
+let event, playlist, clientSocket;
 describe('events', () => {
   beforeAll(async(done) => {
-    db = require('../../server/db');
-    conn = await db.establishConnection();
-
     playlist = {id: 1, entries: ['smoothJams', 'marvinGaye']};
     const data = [playlist, {id: 2, entries: ['heavyMetal', 'blink182']}];
 
-    await db.insert({tableName: 'playlists', data}, conn);
+    await db.insert({tableName: 'playlists', data});
 
     clientSocket = await io.connect(`http://localhost:${process.env.PORT}`);
     clientSocket.on('connect', function() {
@@ -20,7 +18,6 @@ describe('events', () => {
   });
 
   afterAll(() => {
-    conn.close();
     clientSocket.disconnect();
   });
 
@@ -45,7 +42,7 @@ describe('events', () => {
           done();
         });
         playlist = {id: 1, entries: ['smoothJams', 'marvinGaye', 'newSong']};
-        await db.update({tableName: 'playlists', id: 1, data: playlist}, conn);
+        await db.update({tableName: 'playlists', id: 1, data: playlist});
       });
 
       it('returns the updated playlist', () => {
@@ -60,7 +57,7 @@ describe('events', () => {
           done();
         });
         playlist = {id: 1, entries: ['smoothJams']};
-        await db.update({tableName: 'playlists', id: 1, data: playlist}, conn);
+        await db.update({tableName: 'playlists', id: 1, data: playlist});
       });
 
       it('returns the updated playlist', () => {
@@ -78,7 +75,7 @@ describe('events', () => {
 
     it('updates the playlist', async(done) => {
       setTimeout(async() => {
-        const dbPlaylist = await db.get({tableName: 'playlists', id: 1}, conn);
+        const dbPlaylist = await db.get({tableName: 'playlists', id: 1});
         expect(dbPlaylist).toEqual(playlist);
         done();
       }, 1000);

--- a/spec/server/spec_helper.js
+++ b/spec/server/spec_helper.js
@@ -2,18 +2,9 @@ require('../spec_helper');
 const {tables} = require('../../server/db.json');
 const db = require('../../server/db');
 
-let conn;
-
 beforeAll(async (done) => {
-  conn = await db.establishConnection();
-  const dbs = await db.listDbs(conn);
-  if (dbs.includes('test')) await db.drop('test', conn);
-  await db.init({tables}, conn);
-  done();
-});
-
-afterAll(async (done) => {
-  //TODO: teardown test db
-  await conn.close();
+  const dbs = await db.listDbs();
+  if (dbs.includes('test')) await db.drop('test');
+  await db.init({tables});
   done();
 });

--- a/tasks/db.js
+++ b/tasks/db.js
@@ -3,15 +3,11 @@ const db = require('../server/db');
 const {tables} = require('../server/db.json');
 
 gulp.task('db-init', async function() {
-  const conn = await db.establishConnection();
-  await db.init({tables}, conn);
+  await db.init({tables});
   const playlist = {id: 1, entries: ['smoothJams', 'marvinGaye']};
-  await db.insert({tableName: 'playlists', data: playlist}, conn);
-  conn.close();
+  await db.insert({tableName: 'playlists', data: playlist});
 });
 
 gulp.task('db-drop', async function() {
-  const conn = await db.establishConnection();
-  await db.drop('development', conn);
-  conn.close();
+  await db.drop('development');
 });


### PR DESCRIPTION
## RethinkDb Connections 🔬  🔥

Experiment with `rethinkdbdash`, which efficiently manages rethinkdb connections for us, without compromising any of our previous ReQL queries. From the docs:

> Rethinkdbdash uses almost the same API as the official driver. Please refer to the official driver's documentation for all the ReQL methods (the methods used to build the query).
> 
> Connections are managed by the driver with an efficient connection pool. Once you have imported the driver, you can immediately run queries, you don't need to call `r.connect`, or pass a connection to `run`.

https://github.com/neumino/rethinkdbdash
